### PR TITLE
fix: Resolve comment formatting conflict with prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,15 @@ module.exports = {
 		'jsx-quotes': [2, 'prefer-double'],
 		'key-spacing': 2,
 		'keyword-spacing': 2,
-		'lines-around-comment': 1,
+		'lines-around-comment': [
+			1,
+			{
+				"beforeBlockComment": true,
+				"allowBlockStart": true,
+				"allowObjectStart": true,
+				"allowArrayStart": true
+			}
+		],
 		'new-cap': 1,
 		'new-parens': 2,
 		'no-alert': 1,


### PR DESCRIPTION
By using both the jvdx prettier and the jvdx eslint config, we run into the following issue:
https://nicedoc.io/prettier/eslint-config-prettier#lines-around-comment

This patch resolves it by making eslint more permissive here.